### PR TITLE
Remove installer user cleanup

### DIFF
--- a/akanda-linux/cleanup.sh
+++ b/akanda-linux/cleanup.sh
@@ -14,10 +14,6 @@ mkdir /etc/udev/rules.d/70-persistent-net.rules
 rm -rf /dev/.udev/
 rm /lib/udev/rules.d/75-persistent-net-generator.rules
 
-# no more postinstall scipts after this
-userdel -f -r installer
-rm /etc/sudoers.d/installer
-
 # Zero out the free space to save space in the final image:
 dd if=/dev/zero of=/EMPTY bs=1M
 rm -f /EMPTY


### PR DESCRIPTION
So that we can still run veewee ssh/copy's after the build is completed.
