### PR TITLE
set the nameservers and make sure /EMPTY is rm'd

### DIFF
--- a/Centos65/dhc.sh
+++ b/Centos65/dhc.sh
@@ -37,6 +37,15 @@ resize_rootfs_tmp: /dev
 ssh_deletekeys:   0
 ssh_genkeytypes:  ~
 syslog_fix_perms: ~
+manage-resolv-conf: true
+
+resolv_conf:
+  nameservers: ['8.8.4.4', '8.8.8.8']
+  domain: nodes.dreamcompute.com
+  options:
+    rotate: true
+    timeout: 1
+
 
 cloud_init_modules:
  - migrator

--- a/Centos65/zerodisk.sh
+++ b/Centos65/zerodisk.sh
@@ -1,3 +1,4 @@
 # Zero out the free space to save space in the final image:
 dd if=/dev/zero of=/EMPTY bs=1M
 rm -f /EMPTY
+sync


### PR DESCRIPTION
The nameserver was being left as 192.168.122.1 (the libvirt default network).

Also, /EMPTY wasn't removed from the disk image.  I'm guessing this sync call will fix that.
