### PR TITLE
Fix apt-listchanges hangups

### DIFF
--- a/Debian-7.0-Wheezy/base.sh
+++ b/Debian-7.0-Wheezy/base.sh
@@ -1,8 +1,8 @@
 # Update the box
 apt-get -y update
-apt-get -y install linux-headers-$(uname -r) build-essential
-DEBIAN_FRONTEND=noninteractive apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev
-apt-get -y install curl unzip
+APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y install linux-headers-$(uname -r) build-essential
+APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev
+APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y install curl unzip
 
 # Set up sudo
 echo 'installer ALL=NOPASSWD:ALL' > /etc/sudoers.d/vagrant

--- a/Debian-7.0-Wheezy/dhc.sh
+++ b/Debian-7.0-Wheezy/dhc.sh
@@ -1,9 +1,9 @@
 /bin/echo "cloud-init cloud-init/datasources string ConfigDrive" | /usr/bin/debconf-set-selections        
 /bin/echo "deb http://http.debian.net/debian wheezy-backports main" > /etc/apt/sources.list.d/wheezy_backports.list
 /usr/bin/apt-get update
-/usr/bin/apt-get -y install cloud-init cloud-initramfs-growroot
-/usr/bin/apt-get -y dist-upgrade
-/usr/bin/apt-get -y -t wheezy-backports install linux-image-amd64
+APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y install cloud-init cloud-initramfs-growroot
+APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y dist-upgrade
+APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y -t wheezy-backports install linux-image-amd64
 cat > /etc/default/grub << EOF
 # If you change this file, run 'update-grub' afterwards to update
 # /boot/grub/grub.cfg.


### PR DESCRIPTION
This patch addresses an issue with veewee hanging up on some changelogs
being displayed (thanks to apt-listchanges).  This is accomplished by
setting APT_LISTCHANGES_FRONTEND=none before apt-get install operations.
