### PR TITLE
Add a yum upgrade to CentOS65

### DIFF
--- a/Centos65/base.sh
+++ b/Centos65/base.sh
@@ -10,6 +10,8 @@ enabled=1
 gpgcheck=0
 EOM
 
+yum -y upgrade
+
 yum -y install gcc make gcc-c++ kernel-devel-`uname -r` zlib-devel openssl-devel readline-devel sqlite-devel perl wget dkms nfs-utils
 
 # Make ssh faster by not waiting on DNS


### PR DESCRIPTION
This patch adds a 'yum upgrade' to base.sh to ensure we have the latest
packages for each build.  The key driver for this at this time is the
shellshock bash bug, but should simplifiy things for future patching.

Fixes: DHC-2458
