### PR TITLE
Gitlab post script for Ubuntu 14.04

### DIFF
--- a/Ubuntu-14.04-Trusty/definition.rb
+++ b/Ubuntu-14.04-Trusty/definition.rb
@@ -42,6 +42,7 @@ Veewee::Definition.declare({
     "base.sh",
 #    "vagrant.sh",
     "dhc.sh",
+    "_gitlab.sh",
     "cleanup.sh",
     "zerodisk.sh"
   ],

--- a/Ubuntu-14.04-Trusty/gitlab.sh
+++ b/Ubuntu-14.04-Trusty/gitlab.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+#
+echo "Installing gitlab omnibus"
+wget https://downloads-packages.s3.amazonaws.com/ubuntu-14.04/gitlab_7.7.2-omnibus.5.4.2.ci-1_amd64.deb
+dpkg -i gitlab_7.7.2-omnibus.5.4.2.ci-1_amd64.deb


### PR DESCRIPTION
Installs the gitlab omnibus pacakge. By default
this post script is disabled. It can be enabled
with post script cli flags at build time.