### PR TITLE
Setup scripts-per-* cloud init modules in trusty

### DIFF
--- a/Ubuntu-14.04-Trusty/dhc.sh
+++ b/Ubuntu-14.04-Trusty/dhc.sh
@@ -45,6 +45,9 @@ cloud_init_modules:
  - update_etc_hosts
  - rsyslog
  - users-groups
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
  - ssh
 
 cloud_config_modules:


### PR DESCRIPTION
Sets up cloud.cfg to run scripts-per-* on cloud-init runs.