### PR TITLE
Remove nfs-common install

### DIFF
--- a/Ubuntu-12.04-Precise/base.sh
+++ b/Ubuntu-12.04-Precise/base.sh
@@ -15,6 +15,3 @@ apt-get clean
 #) > /tmp/vagrant
 #chmod 0440 /tmp/vagrant
 #mv /tmp/vagrant /etc/sudoers.d/
-
-# Install NFS client
-apt-get -y install nfs-common


### PR DESCRIPTION
This patch removes nfs-common install from the veewee build processes
for the Ubuntu-12.04-Precise image.  This package is causing the veewee
build to fail (likely due to mirrors being messed up).  However, this
really is an optional package, so it is reasonable to leave it to the
user to install this package, should the actually want it.