### PR TITLE
Clean out repo hashes before package installs

### DIFF
--- a/Ubuntu-12.04-Precise/base.sh
+++ b/Ubuntu-12.04-Precise/base.sh
@@ -1,6 +1,9 @@
 
 # Apt-install various things necessary for Ruby, guest additions,
 # etc., and remove optional things to trim down the machine.
+
+# cleanout possibly stale repo hashes
+rm -rf /var/lib/apt/lists/*
 apt-get -y update
 apt-get -y upgrade
 apt-get -y install build-essential linux-headers-$(uname -r) #gcc


### PR DESCRIPTION
This patch addresses a bug with installing some packages (namely
nfs-common) by cleaning out repo hashes before starting package
installs.