### PR TITLE
Ensure dhc-user is create for Precise

### DIFF
--- a/Ubuntu-12.04-Precise/dhc.sh
+++ b/Ubuntu-12.04-Precise/dhc.sh
@@ -1,7 +1,7 @@
 /bin/echo "cloud-init cloud-init/datasources string ConfigDrive" | /usr/bin/debconf-set-selections        
-#/usr/sbin/useradd -s /bin/bash -m dhc-user
-#echo "dhc-user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/dhc-user
-#chmod 440 /etc/sudoers.d/dhc-user
+/usr/sbin/useradd -s /bin/bash -m dhc-user
+echo "dhc-user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/dhc-user
+chmod 440 /etc/sudoers.d/dhc-user
 /usr/bin/apt-get -y install cloud-init cloud-initramfs-rescuevol cloud-initramfs-growroot python-setuptools
 rm /etc/network/if-up.d/ntpdate
 rm /etc/default/grub


### PR DESCRIPTION
This patch addresses a bug where the dhc-user was not being created
properly for the Precise image.