### PR TITLE
Fix Fedora-21 automation

### DIFF
--- a/Fedora-21/definition.rb
+++ b/Fedora-21/definition.rb
@@ -15,7 +15,7 @@ Veewee::Session.declare({
   :hwvirtext => 'on',
   :os_type_id => 'Fedora_64',
   :iso_file => "Fedora-Server-DVD-x86_64-21.iso",
-  :iso_src => "http://fedora.mirror.lstn.net/releases/21/Server/x86_64/iso/Fedora-Server-DVD-x86_64-21.iso",
+  :iso_src => "http://download.fedoraproject.org/pub/fedora/linux/releases/21/Server/x86_64/iso/Fedora-Server-DVD-x86_64-21.iso",
   :iso_sha256 => "a6a2e83bb409d6b8ee3072ad07faac0a54d79c9ecbe3a40af91b773e2d843d8e",
   :iso_download_timeout => 1000,
   :boot_wait => "10",

--- a/Fedora-21/ks.cfg.erb
+++ b/Fedora-21/ks.cfg.erb
@@ -6,12 +6,13 @@ lang en_US.UTF-8
 keyboard 'us'
 # note we set biosdevname=0 when launching install
 # this means we will be using standard ethernet devices, e.g. eth[0,1,2] eth
-network --onboot yes --device eth0 --bootproto dhcp --noipv6 --hostname=localhost.localdomain
+network --onboot yes --device eth0 --bootproto static --ip=192.168.122.171 --netmask=255.255.255.0 --gateway=192.168.122.1 --nameserver=8.8.8.8 --noipv6 --hostname=localhost.localdomain
+
 timezone --utc Etc/UTC
 rootpw  --iscrypted $6$n/NGsk5H2aiBMXL4$r/oPkJtB5rasvQHPo9AvIJBe6sNVlQbpZxvTRMN7.qZk/Sn9u2qZ0XgNxflUvK20y7OIWdr/vv7MED6gzkBiH0
 selinux --enforcing
 auth --enableshadow --passalgo=sha512
-firewall --service=sshd
+firewall --service=ssh
 
 # Avoiding warning message on Storage device breaking automated generation
 zerombr
@@ -30,7 +31,7 @@ clearpart --all --initlabel
 #logvol / --fstype=ext4 --name=lv_root --vgname=vg_dhc --size=1024 --grow
 #logvol swap --fstype=swap --name=lv_swap --vgname=vg_dhc --size=528 --grow --maxsize=1056
 partition / --grow --fstype=ext4
-bootloader --extlinux --location=mbr --append="net.ifnames=0 biosdevname=0 console=tty1 console=ttyS0,115200n8"
+bootloader --location=mbr --append="norhgb net.ifnames=0 biosdevname=0 console=tty1 console=ttyS0,115200n8"
 services --enabled network
 reboot
 


### PR DESCRIPTION
Fedora-21 is getting a different IP between kickstart and reboot.  This
patch sets a static IP so we don't have to rely on DHCP.  Also, a new
image source is selected as the other image source seemed to timeout
periodically.