### PR TITLE
don't use mirror.newdream.net for image installs

### DIFF
--- a/Ubuntu-14.04/preseed.cfg.erb
+++ b/Ubuntu-14.04/preseed.cfg.erb
@@ -77,12 +77,12 @@ d-i pkgsel/update-policy select none
 
 # debconf-get-selections --install
 #Use mirror
-d-i apt-setup/use_mirror boolean true
-d-i mirror/country string manual
-choose-mirror-bin mirror/protocol string http
-choose-mirror-bin mirror/http/hostname string mirror.newdream.net
-choose-mirror-bin mirror/http/directory string /ubuntu
-choose-mirror-bin mirror/suite select main
+#d-i apt-setup/use_mirror boolean true
+#d-i mirror/country string manual
+#choose-mirror-bin mirror/protocol string http
+#choose-mirror-bin mirror/http/hostname string mirror.newdream.net
+#choose-mirror-bin mirror/http/directory string /ubuntu
+#choose-mirror-bin mirror/suite select main
 #d-i debian-installer/allow_unauthenticated string true
 
 choose-mirror-bin mirror/http/proxy string


### PR DESCRIPTION
This was changed for my personal machine at home and I forgot
to change it back.