### PR TITLE
Clear yum fastest mirror cache

### DIFF
--- a/Centos-6.5/cleanup.sh
+++ b/Centos-6.5/cleanup.sh
@@ -3,6 +3,9 @@ yum -y clean all
 rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
 rm -rf VBoxGuestAdditions_*.iso
 
+#cleanup yum fastest mirror cache
+rm -f /var/cache/yum/timedhosts.txt
+
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
 rm /etc/udev/rules.d/70-persistent-net.rules

--- a/Centos-6.6/cleanup.sh
+++ b/Centos-6.6/cleanup.sh
@@ -3,6 +3,9 @@ yum -y clean all
 rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
 rm -rf VBoxGuestAdditions_*.iso
 
+#cleanup yum fastest mirror cache
+rm -f /var/cache/yum/timedhosts.txt
+
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
 rm /etc/udev/rules.d/70-persistent-net.rules

--- a/Centos-7.0/cleanup.sh
+++ b/Centos-7.0/cleanup.sh
@@ -3,6 +3,9 @@ yum -y clean all
 rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
 rm -rf VBoxGuestAdditions_*.iso
 
+#cleanup yum fastest mirror cache
+rm -f /var/cache/yum/timedhosts.txt
+
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
 rm -f /etc/udev/rules.d/70-persistent-net.rules

--- a/Fedora-20/cleanup.sh
+++ b/Fedora-20/cleanup.sh
@@ -2,5 +2,8 @@ yum -y erase gtk2 libX11 hicolor-icon-theme avahi bitstream-vera-fonts
 yum -y clean all
 rm -rf VBoxGuestAdditions_*.iso
 
+#cleanup yum fastest mirror cache
+rm -f /var/cache/yum/timedhosts.txt
+
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0

--- a/Fedora-21/cleanup.sh
+++ b/Fedora-21/cleanup.sh
@@ -2,6 +2,9 @@ yum -y erase gtk2 libX11 hicolor-icon-theme avahi bitstream-vera-fonts
 yum -y clean all
 rm -rf VBoxGuestAdditions_*.iso
 
+#cleanup yum fastest mirror cache
+rm -f /var/cache/yum/timedhosts.txt
+
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
 rm /root/anaconda-ks.cfg


### PR DESCRIPTION
Yum caches which mirror it deems is fastest.  This patch removes this
cache from yum based distros so that the first time the user runs yum,
it will re-determine which mirror is the fastest, which could easily
have changed from image creation time to the time a VM is spun up from
this image.