### PR TITLE
Remove vagrant references for Debian 7.0/8.0

### DIFF
--- a/Debian-7.0/base.sh
+++ b/Debian-7.0/base.sh
@@ -4,9 +4,6 @@ APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y install 
 APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev
 APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y install curl unzip
 
-# Set up sudo
-echo 'installer ALL=NOPASSWD:ALL' > /etc/sudoers.d/vagrant
-
 # Tweak sshd to prevent DNS resolution (speed up logins)
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 

--- a/Debian-7.0/definition.rb
+++ b/Debian-7.0/definition.rb
@@ -45,7 +45,6 @@ Veewee::Definition.declare({
      'locale=en_US ',
      'kbd-chooser/method=us ',
      'netcfg/get_hostname=%NAME% ',
-     'netcfg/get_domain=vagrantup.com ',
      'fb=false ',
      'debconf/frontend=noninteractive ',
      'console-setup/ask_detect=false ',

--- a/Debian-7.0/preseed.cfg.erb
+++ b/Debian-7.0/preseed.cfg.erb
@@ -36,12 +36,6 @@ d-i netcfg/choose_interface select auto
 #d-i netcfg/get_gateway string 192.168.1.1
 #d-i netcfg/confirm_static boolean true
 
-# Any hostname and domain names assigned from dhcp take precedence over
-# values set here. However, setting the values still prevents the questions
-# from being shown, even if values come from dhcp.
-#d-i netcfg/get_hostname string vagrant
-d-i netcfg/get_domain string vagrantup.com
-
 # Disable that annoying WEP key dialog.
 d-i netcfg/wireless_wep string
 # The wacky dhcp hostname that some ISPs use as a password of sorts.

--- a/Debian-8.0/base.sh
+++ b/Debian-8.0/base.sh
@@ -4,9 +4,6 @@ APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y install 
 APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y install zlib1g-dev libssl-dev libreadline-gplv2-dev
 APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y install curl unzip
 
-# Set up sudo
-echo 'installer ALL=NOPASSWD:ALL' > /etc/sudoers.d/vagrant
-
 # Tweak sshd to prevent DNS resolution (speed up logins)
 echo 'UseDNS no' >> /etc/ssh/sshd_config
 

--- a/Debian-8.0/definition.rb
+++ b/Debian-8.0/definition.rb
@@ -45,7 +45,6 @@ Veewee::Definition.declare({
      'locale=en_US ',
      'kbd-chooser/method=us ',
      'netcfg/get_hostname=%NAME% ',
-     'netcfg/get_domain=vagrantup.com ',
      'fb=false ',
      'debconf/frontend=noninteractive ',
      'console-setup/ask_detect=false ',

--- a/Debian-8.0/preseed.cfg.erb
+++ b/Debian-8.0/preseed.cfg.erb
@@ -253,6 +253,12 @@ d-i grub-installer/only_debian boolean true
 # OS, which is less safe as it might not be able to boot that other OS.
 d-i grub-installer/with_other_os boolean true
 
+# Due notably to potential USB sticks, the location of the MBR can not be
+# determined safely in general, so this needs to be specified:
+#d-i grub-installer/bootdev  string /dev/sda
+# To install to the first device (assuming it is not a USB stick):
+d-i grub-installer/bootdev  string default
+
 # Alternatively, if you want to install to a location other than the mbr,
 # uncomment and edit these lines:
 #d-i grub-installer/only_debian boolean false

--- a/Debian-8.0/preseed.cfg.erb
+++ b/Debian-8.0/preseed.cfg.erb
@@ -36,12 +36,6 @@ d-i netcfg/choose_interface select auto
 #d-i netcfg/get_gateway string 192.168.1.1
 #d-i netcfg/confirm_static boolean true
 
-# Any hostname and domain names assigned from dhcp take precedence over
-# values set here. However, setting the values still prevents the questions
-# from being shown, even if values come from dhcp.
-#d-i netcfg/get_hostname string vagrant
-d-i netcfg/get_domain string vagrantup.com
-
 # Disable that annoying WEP key dialog.
 d-i netcfg/wireless_wep string
 # The wacky dhcp hostname that some ISPs use as a password of sorts.


### PR DESCRIPTION
This patch removes vagrant references in the veewee scripts for the
Debian 7.0 and 8.0 images.  These references shouldn't be needed as we
do things with generated values (for things like passwords and domains).