### PR TITLE
Ubuntu-14.04 re-use mountall magic

### DIFF
--- a/Ubuntu-14.04/definition.rb
+++ b/Ubuntu-14.04/definition.rb
@@ -13,9 +13,9 @@ Veewee::Definition.declare({
   :disk_format => 'raw',
   :hostiocache => 'off',
   :os_type_id => 'Ubuntu_64',
-  :iso_file => "ubuntu-14.04-server-amd64.iso",
-  :iso_src => "http://releases.ubuntu.com/14.04/ubuntu-14.04-server-amd64.iso",
-  :iso_md5 => '01545fa976c8367b4f0d59169ac4866c',
+  :iso_file => "ubuntu-14.04.2-server-amd64.iso",
+  :iso_src => "http://releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso",
+  :iso_md5 => '83aabd8dcf1e8f469f3c72fff2375195',
   :iso_download_timeout => "1000",
   :boot_wait => "10",
   :boot_cmd_sequence => [
@@ -42,7 +42,7 @@ Veewee::Definition.declare({
     "base.sh",
 #    "vagrant.sh",
     "dhc.sh",
-    "_install_application.sh",
+#    "_install_application.sh",
     "cleanup.sh",
     "zerodisk.sh"
   ],

--- a/Ubuntu-14.04/dhc.sh
+++ b/Ubuntu-14.04/dhc.sh
@@ -122,5 +122,5 @@ search nodes.dreamcompute.net
 EOF
 
 ## Explicitly mounting the config drive seems to work around a bug in mountall
-mkdir /mnt/config-2
-echo '/dev/sr0 /mnt/config-2 iso9660 defaults 0 0' >> /etc/fstab
+#mkdir /mnt/config-2
+#echo '/dev/sr0 /mnt/config-2 iso9660 defaults 0 0' >> /etc/fstab


### PR DESCRIPTION
In an attempt to support both vfat and iso config drives, this patch
removes the fstab mount and leverages mountall (again).  There is a
known bug in mountall, but we'll address that later...