### PR TITLE
Ubuntu-14.04: Clear mtab on first boot

### DIFF
--- a/Ubuntu-14.04/dhc.sh
+++ b/Ubuntu-14.04/dhc.sh
@@ -106,9 +106,6 @@ growpart:
 
 resize_rootfs: True
 
-bootcmd:
- - [ cloud-init-per, once, wipemtab, cat, /proc/mounts, >, /etc/mtab ]
-
 EOF
 cat >> /etc/cloud/cloud.cfg.d/99_cleanup.cfg << EOF
 

--- a/Ubuntu-14.04/dhc.sh
+++ b/Ubuntu-14.04/dhc.sh
@@ -110,6 +110,7 @@ EOF
 cat >> /etc/cloud/cloud.cfg.d/99_cleanup.cfg << EOF
 
 runcmd:
+ - [ /bin/sed, -i, 's/\/tmp\/.*. vfat .*./d', /etc/mtab ]
  - [ /usr/sbin/userdel, -r, installer ]
  - [ /bin/rm, -f, /etc/cloud/cloud.cfg.d/99_cleanup.cfg]
 


### PR DESCRIPTION
We've seen issues surrounding a dirty mtab on first boot.  /proc/mounts
seems to be correct, so the first boot should just re-init the mtab with
what is in /proc/mounts.