### PR TITLE
Ubuntun-14.04: fix mtab cleanup syntax

### DIFF
--- a/Ubuntu-14.04/dhc.sh
+++ b/Ubuntu-14.04/dhc.sh
@@ -110,7 +110,7 @@ EOF
 cat >> /etc/cloud/cloud.cfg.d/99_cleanup.cfg << EOF
 
 runcmd:
- - [ /bin/sed, -i, 's/\/tmp\/.*. vfat .*./d', /etc/mtab ]
+ - [ /bin/sed, -i, '/\/tmp\/.*. vfat .*./d', /etc/mtab ]
  - [ /usr/sbin/userdel, -r, installer ]
  - [ /bin/rm, -f, /etc/cloud/cloud.cfg.d/99_cleanup.cfg]
 


### PR DESCRIPTION
The previous commit attempted to cleanup by using sed to remove specific
entries from mtab.  However, there was a syntax error.  This patch
addresses the syntax error.
