### PR TITLE
Ensure EPEL is working for Centos7

### DIFF
--- a/Centos-7.0/cleanup.sh
+++ b/Centos-7.0/cleanup.sh
@@ -1,6 +1,6 @@
 yum -y erase gtk2 libX11 hicolor-icon-theme avahi bitstream-vera-fonts
 yum -y clean all
-rm -rf /etc/yum.repos.d/{puppetlabs,epel}.repo
+rm -rf /etc/yum.repos.d/puppetlabs.repo
 rm -rf VBoxGuestAdditions_*.iso
 
 #cleanup yum fastest mirror cache

--- a/Centos-7.0/definition.rb
+++ b/Centos-7.0/definition.rb
@@ -12,9 +12,9 @@ Veewee::Session.declare({
   :disk_format => 'raw',
   :hostiocache => 'off',
   :os_type_id => 'Centos_64',
-  :iso_file => "CentOS-7.0-1406-x86_64-Minimal.iso",
-  :iso_src => "http://ftp.osuosl.org/pub/centos/7.0.1406/isos/x86_64/CentOS-7.0-1406-x86_64-Minimal.iso",
-  :iso_md5 => "e3afe3f1121d69c40cc23f0bafa05e5d",
+  :iso_file => "CentOS-7-x86_64-Minimal-1503-01.iso",
+  :iso_src => "http://lug.mtu.edu/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1503-01.iso",
+  :iso_md5 => "d07ab3e615c66a8b2e9a50f4852e6a77",
   :iso_download_timeout => 1000,
   :boot_wait => "10",
   :boot_cmd_sequence => [

--- a/Centos-7.0/dhc.sh
+++ b/Centos-7.0/dhc.sh
@@ -4,7 +4,6 @@ cat >> /etc/chkconfig.d/cloud-init-local << EOF
 # chkconfig: 2345 09 90
 EOF
 #/bin/yum -y update
-/bin/rpm -Uvh http://linux.mirrors.es.net/fedora-epel/7/x86_64/e/epel-release-7-5.noarch.rpm
 /usr/bin/yum -y install cloud-utils-growpart cloud-init syslinux-extlinux dracut-tools
 /usr/bin/yum -y erase firewalld NetworkManager
 /sbin/dracut --force


### PR DESCRIPTION
This patch ensures that the EPEL repo is working on the Centos 7.0
image.  There were conflicting lines on dhc.sh and cleanup.sh.  dhc.sh
was installing epel (as was base.sh...) and cleanup.sh was removing it.
This patch assumes we do indeed want EPEL enabled and removes the
deletion of the repo from the cleanup.sh script.