### PR TITLE
Ubuntu-14.04: only set hostname once

### DIFF
--- a/Ubuntu-14.04/dhc.sh
+++ b/Ubuntu-14.04/dhc.sh
@@ -41,8 +41,6 @@ cloud_init_modules:
  - growpart
  - resizefs
  - set_hostname
- - update_hostname
- - update_etc_hosts
  - rsyslog
  - users-groups
  - scripts-per-once


### PR DESCRIPTION
Cloud-init has a great feature where it can reset your VMs hostname
unless you tell it to stop.  While we do want to set the hostname once,
we do not want to keep resetting it after every reboot.  This patch
disables the 'update_hostname' and 'update_etc_hosts' modules for
cloud-init, but leaves the 'set_hostname' module.  This should allow the
first boot to set the hostname and subsequent boots to leave the
hostname alone, should it change.