### PR TITLE
Ubuntu-14.04: close compiled preseed file

### DIFF
--- a/Ubuntu-14.04/definition.rb
+++ b/Ubuntu-14.04/definition.rb
@@ -4,6 +4,7 @@ ssh_password = Array.new(24){[*'0'..'9', *'a'..'z', *'A'..'Z'].sample}.join
 parsed = ERB.new(File.read("preseed.cfg.erb")).result(binding)
 out = File.new('preseed.cfg', 'w')
 out.write(parsed)
+out.close
 
 
 Veewee::Definition.declare({


### PR DESCRIPTION
After processsing the template, the preseed.cfg file is supposed to be
written to disk, then served via veewee.  However, it appears as though
ruby 2.1.0 is leaving the file handle open and not flushing to disk, so
the subsequent serving of preseed.cfg just serves a blank/empty file.
This patch adds an out.close call to ensure that the file is flushed to
disk.