### PR TITLE
All: Remove update_hostname/etc_hosts modules

### DIFF
--- a/Centos-6/cleanup.sh
+++ b/Centos-6/cleanup.sh
@@ -9,3 +9,7 @@ rm -f /var/cache/yum/timedhosts.txt
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
 rm /etc/udev/rules.d/70-persistent-net.rules
+
+# remove auto-created /etc/hosts entry
+echo "cleaning out /etc/hosts entries"
+sed -i 's/127.0.1.1.*//' /etc/hosts

--- a/Centos-6/dhc.sh
+++ b/Centos-6/dhc.sh
@@ -49,8 +49,6 @@ cloud_init_modules:
  - growpart
  - resizefs
  - set_hostname
- - update_hostname
- - update_etc_hosts
  - resolv_conf
  - rsyslog
  - users-groups

--- a/Centos-7/cleanup.sh
+++ b/Centos-7/cleanup.sh
@@ -9,3 +9,7 @@ rm -f /var/cache/yum/timedhosts.txt
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
 rm -f /etc/udev/rules.d/70-persistent-net.rules
+
+# remove auto-created /etc/hosts entry
+echo "cleaning out /etc/hosts entries"
+sed -i 's/127.0.1.1.*//' /etc/hosts

--- a/Centos-7/dhc.sh
+++ b/Centos-7/dhc.sh
@@ -49,8 +49,6 @@ cloud_init_modules:
  - growpart
  - resizefs
  - set_hostname
- - update_hostname
- - update_etc_hosts
  - resolv_conf
  - rsyslog
  - users-groups

--- a/Coreos/cleanup.sh
+++ b/Coreos/cleanup.sh
@@ -4,3 +4,7 @@ rm -rf VBoxGuestAdditions_*.iso
 
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
+
+# remove auto-created /etc/hosts entry
+echo "cleaning out /etc/hosts entries"
+sed -i 's/127.0.1.1.*//' /etc/hosts

--- a/Coreos/dhc.sh
+++ b/Coreos/dhc.sh
@@ -37,8 +37,6 @@ cloud_init_modules:
  - growpart
  - resizefs
  - set_hostname
- - update_hostname
- - update_etc_hosts
  - rsyslog
  - users-groups
  - ssh

--- a/Debian-7.0/cleanup.sh
+++ b/Debian-7.0/cleanup.sh
@@ -16,3 +16,7 @@ rm /lib/udev/rules.d/75-persistent-net-generator.rules
 
 echo "Adding a 2 sec delay to the interface up, to make the dhclient happy"
 echo "pre-up sleep 2" >> /etc/network/interfaces
+
+# remove auto-created /etc/hosts entry
+echo "cleaning out /etc/hosts entries"
+sed -i 's/127.0.1.1.*//' /etc/hosts

--- a/Debian-7.0/dhc.sh
+++ b/Debian-7.0/dhc.sh
@@ -49,8 +49,6 @@ cloud_init_modules:
  - growpart
  - resizefs
  - set_hostname
- - update_hostname
- - update_etc_hosts
  - ca-certs
  - rsyslog
  - users-groups

--- a/Debian-8.0/cleanup.sh
+++ b/Debian-8.0/cleanup.sh
@@ -16,3 +16,7 @@ rm /lib/udev/rules.d/75-persistent-net-generator.rules
 
 echo "Adding a 2 sec delay to the interface up, to make the dhclient happy"
 echo "pre-up sleep 2" >> /etc/network/interfaces
+
+# remove auto-created /etc/hosts entry
+echo "cleaning out /etc/hosts entries"
+sed -i 's/127.0.1.1.*//' /etc/hosts

--- a/Debian-8.0/dhc.sh
+++ b/Debian-8.0/dhc.sh
@@ -49,8 +49,6 @@ cloud_init_modules:
  - growpart
  - resizefs
  - set_hostname
- - update_hostname
- - update_etc_hosts
  - ca-certs
  - rsyslog
  - users-groups

--- a/Debian-8.1/cleanup.sh
+++ b/Debian-8.1/cleanup.sh
@@ -16,3 +16,7 @@ rm /lib/udev/rules.d/75-persistent-net-generator.rules
 
 echo "Adding a 2 sec delay to the interface up, to make the dhclient happy"
 echo "pre-up sleep 2" >> /etc/network/interfaces
+
+# remove auto-created /etc/hosts entry
+echo "cleaning out /etc/hosts entries"
+sed -i 's/127.0.1.1.*//' /etc/hosts

--- a/Debian-8.1/dhc.sh
+++ b/Debian-8.1/dhc.sh
@@ -49,8 +49,6 @@ cloud_init_modules:
  - growpart
  - resizefs
  - set_hostname
- - update_hostname
- - update_etc_hosts
  - ca-certs
  - rsyslog
  - users-groups

--- a/Fedora-20/cleanup.sh
+++ b/Fedora-20/cleanup.sh
@@ -7,3 +7,7 @@ rm -f /var/cache/yum/timedhosts.txt
 
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
+
+# remove auto-created /etc/hosts entry
+echo "cleaning out /etc/hosts entries"
+sed -i 's/127.0.1.1.*//' /etc/hosts

--- a/Fedora-20/dhc.sh
+++ b/Fedora-20/dhc.sh
@@ -38,8 +38,6 @@ cloud_init_modules:
  - growpart
  - resizefs
  - set_hostname
- - update_hostname
- - update_etc_hosts
  - rsyslog
  - users-groups
  - ssh

--- a/Fedora-21/cleanup.sh
+++ b/Fedora-21/cleanup.sh
@@ -8,3 +8,7 @@ rm -f /var/cache/yum/timedhosts.txt
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
 rm /root/anaconda-ks.cfg
+
+# remove auto-created /etc/hosts entry
+echo "cleaning out /etc/hosts entries"
+sed -i 's/127.0.1.1.*//' /etc/hosts

--- a/Fedora-21/dhc.sh
+++ b/Fedora-21/dhc.sh
@@ -38,8 +38,6 @@ cloud_init_modules:
  - growpart
  - resizefs
  - set_hostname
- - update_hostname
- - update_etc_hosts
  - rsyslog
  - users-groups
  - ssh

--- a/Fedora-22/cleanup.sh
+++ b/Fedora-22/cleanup.sh
@@ -8,3 +8,7 @@ rm -f /var/cache/dnf/timedhosts.txt
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
 rm /root/anaconda-ks.cfg
+
+# remove auto-created /etc/hosts entry
+echo "cleaning out /etc/hosts entries"
+sed -i 's/127.0.1.1.*//' /etc/hosts

--- a/Fedora-22/dhc.sh
+++ b/Fedora-22/dhc.sh
@@ -38,8 +38,6 @@ cloud_init_modules:
  - growpart
  - resizefs
  - set_hostname
- - update_hostname
- - update_etc_hosts
  - rsyslog
  - users-groups
  - ssh

--- a/Ubuntu-12.04/cleanup.sh
+++ b/Ubuntu-12.04/cleanup.sh
@@ -3,6 +3,10 @@
 apt-get -y remove linux-headers-$(uname -r) build-essential
 apt-get -y autoremove
 
+# remove auto-created /etc/hosts entry
+echo "cleaning out /etc/hosts entries"
+sed -i 's/127.0.1.1.*//' /etc/hosts
+
 #Clean up tmp
 rm -rf /tmp/*
 

--- a/Ubuntu-14.04/cleanup.sh
+++ b/Ubuntu-14.04/cleanup.sh
@@ -3,6 +3,10 @@
 apt-get -y remove linux-headers-$(uname -r) build-essential
 apt-get -y autoremove
 
+# remove auto-created /etc/hosts entry
+echo "cleaning out /etc/hosts entries"
+sed -i 's/127.0.1.1.*//' /etc/hosts
+
 #Clean up tmp
 rm -rf /tmp/*
 


### PR DESCRIPTION
This patch removes the update_hostname and update_etc_hosts cloud-init
modules in order to allow for the user to provide a hostname and it not
get wiped out by cloud-init on the subsequent boot(s).  Also included is
a cleanup snippet that removes the hostname used during image buildtime
from the /etc/hosts file.