### PR TITLE
Use mountall for 12.04

### DIFF
--- a/Ubuntu-12.04/dhc.sh
+++ b/Ubuntu-12.04/dhc.sh
@@ -53,5 +53,5 @@ search nodes.dreamcompute.net
 EOF
 
 ## Explicitly mounting the config drive seems to work around a bug in mountall
-mkdir /mnt/config-2
-echo '/dev/sr0 /mnt/config-2 iso9660 defaults,ro 0 0' >> /etc/fstab
+#mkdir /mnt/config-2
+#echo '/dev/sr0 /mnt/config-2 iso9660 defaults,ro 0 0' >> /etc/fstab


### PR DESCRIPTION
Our 14.04 image is using mountall to mount the config drive.  This seems
to be working now, as we've moved to ISO config drives.  Hoping this
fixes it for 12.04 as well.