### PR TITLE
Centos-6: add reboot

### DIFF
--- a/Centos-6/definition.rb
+++ b/Centos-6/definition.rb
@@ -40,6 +40,7 @@ Veewee::Session.declare({
 #    "vagrant.sh",
 #    "virtualbox.sh",
     #"vmfusion.sh",
+    "reboot.sh", # required to get growpart to work
     "cleanup.sh",
     "zerodisk.sh"
   ],

--- a/Centos-6/reboot.sh
+++ b/Centos-6/reboot.sh
@@ -1,0 +1,1 @@
+service sshd stop && /sbin/reboot


### PR DESCRIPTION
Growpart isn't working upon the first reboot, so try rebooting before
veewee is done doing it's thing.