### PR TITLE
Debian-7.0: make sudo work without password

### DIFF
--- a/Debian-7.0/dhc.sh
+++ b/Debian-7.0/dhc.sh
@@ -131,3 +131,4 @@ runcmd:
  - [ /bin/rm, -f, /etc/cloud/cloud.cfg.d/99_cleanup.cfg]
 
 EOF
+sed -i 's/) ALL/) NOPASSWD:ALL/g' /etc/sudoers


### PR DESCRIPTION
This seems to be required now, otherwise resizefs wont install correctly