### PR TITLE
Remove Debian-8.3 interface cleanup

### DIFF
--- a/Debian-8.3/cleanup.sh
+++ b/Debian-8.3/cleanup.sh
@@ -20,16 +20,3 @@ echo "pre-up sleep 2" >> /etc/network/interfaces
 # remove auto-created /etc/hosts entry
 echo "cleaning out /etc/hosts entries"
 sed -i 's/127.0.1.1.*//' /etc/hosts
-
-# disable dhcp from eth0
-cat > /etc/network/interfaces << EOF
-# This file describes the network interfaces available on your system
-# and how to activate them. For more information, see interfaces(5).
-
-# The loopback network interface
-auto lo
-iface lo inet loopback
-
-auto eth0
-iface eth0 inet manual
-EOF


### PR DESCRIPTION
The attempt to disable dhcp during the initial boot failed.  Removing
this and seeing if 8.3 has better support for cloud-init, since 8.2.
was breaking.