### PR TITLE
Fedora-23: explicitly enable cloud-init

### DIFF
--- a/Fedora-23/cleanup.sh
+++ b/Fedora-23/cleanup.sh
@@ -12,3 +12,6 @@ rm /root/anaconda-ks.cfg
 # remove auto-created /etc/hosts entry
 echo "cleaning out /etc/hosts entries"
 sed -i 's/127.0.1.1.*//' /etc/hosts
+
+# remove the eth0 file, otherwise cloudinit fails to properly setup eth0
+rm -f /etc/sysconfig/network-scripts/ifcfg-eth0


### PR DESCRIPTION
Apparently, simply installing the cloud-init package does not enable the
service (upon boot).  Thus, we need to explicitly enable it during image
creation.