### PR TITLE
debian-8.3: nuke interfaces

### DIFF
--- a/Debian-8.3/cleanup.sh
+++ b/Debian-8.3/cleanup.sh
@@ -14,9 +14,16 @@ mkdir /etc/udev/rules.d/70-persistent-net.rules
 rm -rf /dev/.udev/
 rm /lib/udev/rules.d/75-persistent-net-generator.rules
 
-echo "Adding a 2 sec delay to the interface up, to make the dhclient happy"
-echo "pre-up sleep 2" >> /etc/network/interfaces
-
 # remove auto-created /etc/hosts entry
 echo "cleaning out /etc/hosts entries"
 sed -i 's/127.0.1.1.*//' /etc/hosts
+
+# Flatten interfaces file so cloudinit can properly set it up
+cat > /etc/network/interfaces << EOF
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+EOF


### PR DESCRIPTION
Cloudinit does not like to properly configure interfaces that are already statically
configured.  Thus, we need to flatten the interfaces file to allow cloudinit to do its thing