### PR TITLE
nuke network configs

### DIFF
--- a/Debian-7.9/cleanup.sh
+++ b/Debian-7.9/cleanup.sh
@@ -14,9 +14,16 @@ mkdir /etc/udev/rules.d/70-persistent-net.rules
 rm -rf /dev/.udev/
 rm /lib/udev/rules.d/75-persistent-net-generator.rules
 
-echo "Adding a 2 sec delay to the interface up, to make the dhclient happy"
-echo "pre-up sleep 2" >> /etc/network/interfaces
-
 # remove auto-created /etc/hosts entry
 echo "cleaning out /etc/hosts entries"
 sed -i 's/127.0.1.1.*//' /etc/hosts
+
+# Flatten interfaces file so cloudinit can properly set it up
+cat > /etc/network/interfaces << EOF
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+EOF

--- a/Fedora-22/cleanup.sh
+++ b/Fedora-22/cleanup.sh
@@ -6,8 +6,10 @@ rm -rf VBoxGuestAdditions_*.iso
 rm -f /var/cache/dnf/timedhosts.txt
 
 # Remove traces of mac address from network configuration
-sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
 rm /root/anaconda-ks.cfg
+# Also cleanup ifcfg-eth0, because cloudinit does not play nice with it already
+# being defined when cloudinit is trying to set static IPs
+rm /etc/sysconfig/network-scripts/ifcfg-eth0
 
 # remove auto-created /etc/hosts entry
 echo "cleaning out /etc/hosts entries"


### PR DESCRIPTION
Similar to the previous commit, we need cleanup intefaces for Debian-7.9 and Fedora-22.