### PR TITLE
Debian-8.3: put nameserver in correct file

### DIFF
--- a/Debian-8.3/dhc.sh
+++ b/Debian-8.3/dhc.sh
@@ -17,7 +17,7 @@ GRUB_CMDLINE_LINUX="debian-installer=en_US"
 EOF
 /usr/sbin/update-grub
 
-cat > /etc/resolvconf/resolv.conf.d/base << EOF
+cat > /etc/resolv.conf << EOF
 nameserver 8.8.8.8
 nameserver 8.8.4.4
 search nodes.dreamcompute.net


### PR DESCRIPTION
Apparently 8.3 isn't using resolvconf? I guess I should read things
about stuff, but in the mean time, we'll dump our settings into the
correct config file.