### PR TITLE
Disable root console login

### DIFF
--- a/Centos-6/dhc.sh
+++ b/Centos-6/dhc.sh
@@ -1,5 +1,6 @@
 /usr/sbin/usermod -a -G wheel installer
 /usr/bin/passwd -d root
+echo > /etc/securetty
 cat >> /etc/chkconfig.d/cloud-init-local << EOF
 # chkconfig: 2345 09 90
 EOF

--- a/Centos-7/dhc.sh
+++ b/Centos-7/dhc.sh
@@ -1,5 +1,6 @@
 /usr/sbin/usermod -a -G wheel installer
 /bin/passwd -d root
+echo > /etc/securetty
 cat >> /etc/chkconfig.d/cloud-init-local << EOF
 # chkconfig: 2345 09 90
 EOF

--- a/Debian-7.9/dhc.sh
+++ b/Debian-7.9/dhc.sh
@@ -1,6 +1,7 @@
 /bin/echo "cloud-init cloud-init/datasources string ConfigDrive" | /usr/bin/debconf-set-selections        
 /bin/echo "deb http://http.debian.net/debian wheezy-backports main" > /etc/apt/sources.list.d/wheezy_backports.list
 /bin/passwd -d root
+echo > /etc/securetty
 /usr/bin/apt-get update
 APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y install cloud-init cloud-initramfs-growroot
 APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y dist-upgrade

--- a/Debian-8.3/dhc.sh
+++ b/Debian-8.3/dhc.sh
@@ -1,6 +1,7 @@
 /bin/echo "cloud-init cloud-init/datasources string ConfigDrive" | /usr/bin/debconf-set-selections        
 /bin/echo "deb http://http.debian.net/debian jessie-backports main" > /etc/apt/sources.list.d/jessie_backports.list
 /usr/bin/passwd -d root
+echo > /etc/securetty
 /usr/bin/apt-get update
 APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y install cloud-init cloud-initramfs-growroot
 APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y dist-upgrade

--- a/Fedora-23/dhc.sh
+++ b/Fedora-23/dhc.sh
@@ -1,5 +1,6 @@
 /usr/sbin/usermod -a -G wheel installer
 /bin/passwd -d root
+echo > /etc/securetty
 #/bin/yum -y update
 /bin/dnf -y install cloud-utils-growpart cloud-init
 /bin/dnf -y erase firewalld NetworkManager


### PR DESCRIPTION
Once we unset the root password, console (vnc) access will still allow
root to login, and now root has no password (doh!).  This patch
disallows root to login via console (vnc).
